### PR TITLE
fix: replaced deprecated APIs that was removed in Flutter v3.19

### DIFF
--- a/lib/flutter_month_picker.dart
+++ b/lib/flutter_month_picker.dart
@@ -123,7 +123,7 @@ class __MonthPickerState extends State<_MonthPicker> {
             Center(
               child: Text(
                 DateFormat.yMMM().format(_selectedDate),
-                style: theme.primaryTextTheme.subtitle1,
+                style: theme.primaryTextTheme.titleMedium,
               ),
             ),
             Row(
@@ -141,7 +141,7 @@ class __MonthPickerState extends State<_MonthPicker> {
                   ),
                 ),
                 DefaultTextStyle(
-                  style: theme.primaryTextTheme.headline5!,
+                  style: theme.primaryTextTheme.headlineSmall!,
                   child: (_isYearSelection)
                       ? Row(
                           mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
This PR updates deprecated TextTheme properties that were removed in Flutter v3.19 and above:

Replaced subtitle1 with titleMedium

Replaced headline5 with headlineSmall

These changes align with the new Material 3 naming conventions introduced in Flutter 3.19.

📄 For more details, refer to the official Flutter changelog:
https://docs.flutter.dev/release/breaking-changes/3-19-deprecations 

Related Issues: #3 


Temporary fix until this PR gets merge:
```
## remove
#flutter_month_picker: ^0.0.2

## replace with
flutter_month_picker:
   git:
     url: https://github.com/EdisonModesto/flutter_month_picker.git
     ref: main # branch name
```